### PR TITLE
pull the correct freetype dll based on platform

### DIFF
--- a/NuGet/SharpFont.Dependencies.props
+++ b/NuGet/SharpFont.Dependencies.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
         <!-- TODO try and make this smarter, at least pick x86/x64, maybe see which MSVC redist is available -->
-        <Content Include="$(MSBuildThisFileDirectory)..\bin\msvc10\x86\freetype6.dll">
+        <Content Include="$(MSBuildThisFileDirectory)..\bin\msvc10\$(PlatformName)\freetype6.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>


### PR DESCRIPTION
Tested with clean builds on both x86 and x64 in my game.