### PR TITLE
Correct license path in nuspec

### DIFF
--- a/NuGet/SharpFont.Dependencies.nuspec
+++ b/NuGet/SharpFont.Dependencies.nuspec
@@ -6,7 +6,7 @@
     <title>SharpFont Dependencies</title>
     <authors>Robert Rouhani</authors>
     <owners>Robert Rouhani</owners>
-    <licenseUrl>https://github.com/Robmaister/SharpFont.Dependencies/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/Robmaister/SharpFont.Dependencies/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>https://github.com/Robmaister/SharpFont.Dependencies</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Native dependencies for SharpFont.</description>


### PR DESCRIPTION
While autocollecting licenses from nuget packages I recognized that the URL in the SharpFont.Dependencies nuget packages is incorrect.
Therefore this change. Would be even nicer to get a new nuget package, even if it does not hange any functionality.